### PR TITLE
Removing validates_presence_of :client from address.rb model

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,8 +3,7 @@ class Address < ApplicationRecord
 
   belongs_to :client
 
-  validates_presence_of :street, :neighborhood, :client
-
+  validates_presence_of :street, :neighborhood
   def fae_display_field
     id
   end


### PR DESCRIPTION
Correção do erro ao criar cliente com address. No model address era verificado a presença do client, como ainda não estava salvo não tinha como existir o client.